### PR TITLE
fix: desktop file name matches package name

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
 		installPhase = ''
 		  mkdir -p $out/bin && mkdir -p $out/opt/zen && cp -r $src/* $out/opt/zen
 		  ln -s $out/opt/zen/zen $out/bin/zen
-		  install -D $desktopSrc/zen.desktop $out/share/applications/zen.desktop
+		  install -D $desktopSrc/zen.desktop $out/share/applications/zen-browser.desktop
 
 		  # install icons
 		  install -D $src/browser/chrome/icons/default/default16.png $out/share/icons/hicolor/16x16/apps/zen.png


### PR DESCRIPTION
This flake would crash my `nixos-rebuild`s with a message stating;

```
 no desktop file for app zen-browser: zen-browser has no 'desktopItem' and no matching desktop file in /nix/store/<hash>-zen-browser-1.7b/share/applications
```

Checking the contents of `/nix/store/<hash>-zen-browser-1.7b/share/applications` reveals a `zen.desktop` but not a `zen-browser.desktop`. Changing the file name (by building a fork of the repo) fixes the build issue.
